### PR TITLE
Add Raspberry Pi 3/4 64-bit (aarch64) build support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,6 +294,25 @@ AS_CASE(["${host_cpu}"],
       AS_HELP_STRING([--enable-imx_gpio], [Enable building support for bitbanging on NXP IMX processors]),
       [build_imx_gpio=$enableval], [build_imx_gpio=no])
   ],
+  [aarch64*], [
+    AC_ARG_ENABLE([ep93xx],
+      AS_HELP_STRING([--enable-ep93xx], [Enable building support for EP93xx based SBCs]),
+      [build_ep93xx=$enableval], [build_ep93xx=no])
+
+    AC_ARG_ENABLE([at91rm9200],
+      AS_HELP_STRING([--enable-at91rm9200], [Enable building support for AT91RM9200 based SBCs]),
+      [build_at91rm9200=$enableval], [build_at91rm9200=no])
+
+    AC_ARG_ENABLE([bcm2835gpio],
+      AS_HELP_STRING([--enable-bcm2835gpio], [Enable building support for bitbanging on BCM2835 (as found in Raspberry Pi)]),
+      [build_bcm2835gpio=$enableval], [build_bcm2835gpio=no])
+    AC_ARG_ENABLE([bcm2835spi],
+      AS_HELP_STRING([--enable-bcm2835spi], [Enable building support for SPI on BCM2835 (as found in Raspberry Pi)]),
+      [build_bcm2835spi=$enableval], [build_bcm2835spi=no])
+    AC_ARG_ENABLE([imx_gpio],
+      AS_HELP_STRING([--enable-imx_gpio], [Enable building support for bitbanging on NXP IMX processors]),
+      [build_imx_gpio=$enableval], [build_imx_gpio=no])
+  ],
   [
     build_ep93xx=no
     build_at91rm9200=no


### PR DESCRIPTION
The current configure.ac file does not allow the 64-bit raspi os to build with support for SPI on BCM2835.
Since it is possible to use 32-bit arm and 64-bit aarch64 with the raspberry pi 3/4, I wanted to add this case to the file.

But I don't really know anything about Autotools and had to look up how AC_CASE works, in order to change this file. That being said I am not sure if all of these options that are supported for arm should also be supported for aarch64.

On my RPi4 I was able to successfully build openocd-spi with support for SPI on BCM2835 using this file. I just can't check all of those other options that can be enabled ow and would appreciate someone checking the code in the [aarch64*] case, to make sure everything is fine.