### PR TITLE
cherry-pick: bitbang: Fix FTBFS with GCC 10

### DIFF
--- a/src/jtag/drivers/bitbang.h
+++ b/src/jtag/drivers/bitbang.h
@@ -57,7 +57,7 @@ struct bitbang_interface {
 	void (*swdio_drive)(bool on);
 };
 
-const struct swd_driver bitbang_swd;
+extern const struct swd_driver bitbang_swd;
 
 extern bool swd_mode;
 


### PR DESCRIPTION
Cherry-pick openocd-org/openocd@c60252ac2b636c4d99b766a574b9df0966151696 to fix build with GCC 10.

---

GCC 10 defaults to -fno-common which breaks the sharing of bitbang_swd
struct between bitbang drivers due to a missing extern.

Change-Id: I2b4122f7939cec91a72284006748f99a23548324
Signed-off-by: Andreas Fritiofson <andreas.fritiofson@gmail.com>
Reviewed-on: http://openocd.zylin.com/5592
Tested-by: jenkins
Reviewed-by: Antonio Borneo <borneo.antonio@gmail.com>
Reviewed-by: Jonathan McDowell <noodles-openocd@earth.li>